### PR TITLE
feat: add the ability to --fix in interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,22 @@ npx jest
 
 yarn jest
 ```
+
+## Toggle `--fix` in watch mode
+
+`jest-stylelint-runner` comes with a watch plugin that allows you to toggle the `--fix` value while in watch mode without having to update your configuration.
+
+To use this watch plugin simply add this to your Jest configuration.
+
+```js
+{
+  watchPlugins: ['jest-runner-stylelint/watch-fix'],
+}
+```
+
+After this run Jest in watch mode and you will see the following line in your watch usage menu.
+
+```
+ › Press F to override Stylelint --fix.
+```
+]

--- a/src/configOverrides.js
+++ b/src/configOverrides.js
@@ -1,0 +1,13 @@
+class ConfigOverrides {
+  setFix(fix) {
+    this.fix = fix;
+  }
+
+  getFix() {
+    return this.fix;
+  }
+}
+
+const configOverrides = new ConfigOverrides();
+
+module.exports = configOverrides;

--- a/src/run.js
+++ b/src/run.js
@@ -1,5 +1,6 @@
 const { pass, fail } = require("create-jest-runner");
 const stylelint = require("stylelint");
+const configOverrides = require("./configOverrides");
 
 module.exports = ({ testPath, config, globalConfig }) => {
   const start = new Date();
@@ -7,7 +8,8 @@ module.exports = ({ testPath, config, globalConfig }) => {
   return stylelint
     .lint({
       files: testPath,
-      formatter: "string"
+      formatter: "string",
+      fix: configOverrides.getFix()
     })
     .then(data => {
       if (data.errored) {

--- a/src/watchFixPlugin.js
+++ b/src/watchFixPlugin.js
@@ -1,0 +1,46 @@
+const { getVersion: getJestVersion } = require("jest");
+const configOverrides = require("./configOverrides");
+
+const majorJestVersion = parseInt(getJestVersion().split(".")[0], 10);
+
+/* istanbul ignore if */
+if (majorJestVersion < 23) {
+  throw new Error(`Insufficient Jest version for jest-runner-stylelint watch plugin
+
+  Watch plugins are only available in Jest 23.0.0 and above.
+  Upgrade your version of Jest in order to use it.
+`);
+}
+
+class StylelintWatchFixPlugin {
+  constructor({ stdout, config }) {
+    this._stdout = stdout;
+    this._key = config.key || "F";
+  }
+
+  async run() {
+    const fix = configOverrides.getFix();
+    configOverrides.setFix(!fix);
+    return true;
+  }
+
+  getUsageInfo() {
+    const getPrompt = () => {
+      const fix = configOverrides.getFix();
+      if (fix === undefined) {
+        return "override Stylelint --fix";
+      }
+      if (!fix) {
+        return "toggle Stylelint --fix (disabled)";
+      }
+      return "toggle Stylelint --fix (enabled)";
+    };
+
+    return {
+      key: this._key,
+      prompt: getPrompt()
+    };
+  }
+}
+
+module.exports = StylelintWatchFixPlugin;

--- a/src/watchFixPlugin.test.js
+++ b/src/watchFixPlugin.test.js
@@ -1,0 +1,61 @@
+jest.useFakeTimers();
+
+let WatchFixPlugin;
+let configOverrides;
+
+describe("watchFixPlugin", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    configOverrides = require("./configOverrides");
+    WatchFixPlugin = require("./watchFixPlugin");
+  });
+
+  it("shows the correct prompt", async () => {
+    const stdout = { write: jest.fn() };
+    const config = {};
+    const plugin = new WatchFixPlugin({ stdout, config });
+    expect(plugin.getUsageInfo()).toEqual({
+      key: "F",
+      prompt: "override Stylelint --fix"
+    });
+
+    await plugin.run(plugin);
+
+    expect(plugin.getUsageInfo()).toEqual({
+      key: "F",
+      prompt: "toggle Stylelint --fix (enabled)"
+    });
+
+    await plugin.run(plugin);
+
+    expect(plugin.getUsageInfo()).toEqual({
+      key: "F",
+      prompt: "toggle Stylelint --fix (disabled)"
+    });
+  });
+
+  it("overrides the setting in configOverrides after each invocation", async () => {
+    const stdout = { write: jest.fn() };
+    const config = {};
+    const plugin = new WatchFixPlugin({ stdout, config });
+    expect(configOverrides.getFix()).toBeUndefined();
+
+    await plugin.run(plugin);
+
+    expect(configOverrides.getFix()).toBe(true);
+
+    await plugin.run(plugin);
+
+    expect(configOverrides.getFix()).toBe(false);
+  });
+
+  it("can customize the key", () => {
+    const stdout = { write: jest.fn() };
+    const config = { key: "z" };
+    const plugin = new WatchFixPlugin({ stdout, config });
+    expect(plugin.getUsageInfo()).toEqual({
+      key: "z",
+      prompt: "override Stylelint --fix"
+    });
+  });
+});

--- a/watch-fix.js
+++ b/watch-fix.js
@@ -1,0 +1,3 @@
+const StylelintWatchFixPlugin = require("./src/watchFixPlugin");
+
+module.exports = StylelintWatchFixPlugin;


### PR DESCRIPTION
Predominantly ~stolen from~ influenced by [jest-runner-eslint](https://github.com/jest-community/jest-runner-eslint).

I'd like to look at adding an override config file too much like [jest-runner-eslint](https://github.com/jest-community/jest-runner-eslint#options) but that can come later.