### PR TITLE
Only set fix from configOverrides when defined

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -6,11 +6,15 @@ const getCliOptions = require("./utils/getCliOptions");
 module.exports = ({ testPath, config }) => {
   const start = new Date();
 
+  const fix = configOverrides.getFix();
+
   const defaultConfig = {
     files: testPath,
     formatter: "string",
-    fix: configOverrides.getFix(),
   };
+
+  if (fix !== undefined) defaultConfig.fix = fix;
+
   const { cliOptions = {} } = getCliOptions(config);
 
   return stylelint


### PR DESCRIPTION
Because options are combined by assigning in this order: `Object.assign({}, cliOptions, defaultConfig))`, it is impossible to set `fix` via `cliOptions` because it will be set to `undefined`.

This PR only set's a value for `fix` on `defaultConfig` if `configOverrides.getFix();` returns  `true` or `false`.
