### PR TITLE
fix watch mode --fix with multiple files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,6 @@
 const { createJestRunner } = require("create-jest-runner");
-module.exports = createJestRunner(require.resolve("./run"));
+const configOverrides = require("./configOverrides");
+
+module.exports = createJestRunner(require.resolve("./run"), {
+  getExtraOptions: () => ({ fix: configOverrides.getFix() }),
+});

--- a/src/run.js
+++ b/src/run.js
@@ -1,15 +1,14 @@
 const { pass, fail } = require("create-jest-runner");
 const stylelint = require("stylelint");
-const configOverrides = require("./configOverrides");
 const getCliOptions = require("./utils/getCliOptions");
 
-module.exports = ({ testPath, config }) => {
+module.exports = ({ testPath, config, extraOptions }) => {
   const start = new Date();
 
   const defaultConfig = {
     files: testPath,
     formatter: "string",
-    fix: configOverrides.getFix(),
+    fix: extraOptions.fix,
   };
   const { cliOptions = {} } = getCliOptions(config);
 

--- a/src/run.test.js
+++ b/src/run.test.js
@@ -22,6 +22,7 @@ describe("jest-runner-stylelint", () => {
         testPath: path.join(__dirname, "__fixtures__", "bad.css"),
         config: {},
         globalConfig: {},
+        extraOptions: {},
       }).then((result) => expect(result).toMatchSnapshot()));
   });
 
@@ -31,6 +32,7 @@ describe("jest-runner-stylelint", () => {
         testPath: path.join(__dirname, "__fixtures__", "good.css"),
         config: {},
         globalConfig: {},
+        extraOptions: {},
       }).then((result) => expect(result).toMatchSnapshot()));
   });
 });


### PR DESCRIPTION
I ran into a problem, where toggling `--fix` via the watch plugin worked fine when I filtered the list of files to 1 file. As soon as I started watching multiple files, however, `--fix` did not work anymore.

It took me quite a while to figure this out, but it looks like somehow this way of creating the runner
```javascript
createJestRunner(require.resolve("./run"));
```
leads to a situation where the import for `configOverrides` in `run.js` creates new objects for each file the runner is run on. Since this object is not the same as the one imported in the watch plugin itself, `.getFix()` always returned undefined, and the fix never worked.

The change in here fixes that, because `configOverrides` is only imported once in `index.js`.

This approach is actually taken from `jest-runner-eslint`, which worked fine for me.